### PR TITLE
This commit adds -no-table-headers to list_users

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -16,7 +16,11 @@ Puppet::Type.type(:rabbitmq_user).provide(
 
   def self.instances
     user_list = run_with_retries do
-      rabbitmqctl('-q', 'list_users')
+      if Facter.value('rabbitmq_version') <= '3.7.8'
+        rabbitmqctl('-q', 'list_users')
+      else
+        rabbitmqctl('--no-table-headers', '-q', 'list_users')
+      end
     end
 
     user_list.split(%r{\n}).map do |line|

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -11,3 +11,4 @@
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+rabbitmq_version: "3.7.8"

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -14,7 +14,7 @@ describe provider_class do
   let(:instance) { provider.class.instances.first }
 
   before do
-    provider.class.stubs(:rabbitmqctl).with('-q', 'list_users').returns(
+    provider.class.stubs(:rabbitmqctl).with('--no-table-headers', '-q', 'list_users').returns(
       "rmq_x [disk, storage]\nrmq_y [network, cpu, administrator]\nrmq_z []\n"
     )
   end


### PR DESCRIPTION
In RabbitMQ 3.7.9 the behaviour of rabbitmqctl -q
has changed, it now also shows a header. With the
parameter '-no-table-headers' this is removed.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
